### PR TITLE
Allow configuration to be given by environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Usage of nextcloud-exporter:
   -u, --username string    Username for connecting to nextcloud.
 ```
 
+Some settings can also be specified through environment variables:
+
+Name                     | Description
+-------------------------|-------------------------------------
+NEXTCLOUD_SERVERINFO_URL | URL to nextcloud serverinfo page
+NEXTCLOUD_USERNAME       | Username for connecting to nextcloud
+NEXTCLOUD_PASSWORD       | Password for connecting to nextcloud
+
+Command line arguments take precedence over environment variables.
+
 After starting the server will offer the metrics on the `/metrics` endpoint, which can be used as a target for prometheus.
 
 The exporter will query the nextcloud server every time it is scraped by prometheus. If you want to reduce load on the nextcloud server you need to change the scrape interval accordingly:

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+	"os"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/pflag"
@@ -24,14 +25,16 @@ func parseConfig() (config, error) {
 	result := config{
 		ListenAddr: ":9205",
 		Timeout:    5 * time.Second,
+		Username:   os.Getenv("NEXTCLOUD_USERNAME"),
+		Password:   os.Getenv("NEXTCLOUD_PASSWORD"),
 	}
 
-	var rawURL string
+	rawURL := os.Getenv("NEXTCLOUD_SERVERINFO_URL");
 	pflag.StringVarP(&result.ListenAddr, "addr", "a", result.ListenAddr, "Address to listen on for connections.")
 	pflag.DurationVarP(&result.Timeout, "timeout", "t", result.Timeout, "Timeout for getting server info document.")
-	pflag.StringVarP(&rawURL, "url", "l", "", "URL to nextcloud serverinfo page.")
-	pflag.StringVarP(&result.Username, "username", "u", "", "Username for connecting to nextcloud.")
-	pflag.StringVarP(&result.Password, "password", "p", "", "Password for connecting to nextcloud.")
+	pflag.StringVarP(&rawURL, "url", "l", rawURL, "URL to nextcloud serverinfo page.")
+	pflag.StringVarP(&result.Username, "username", "u", result.Username, "Username for connecting to nextcloud.")
+	pflag.StringVarP(&result.Password, "password", "p", result.Password, "Password for connecting to nextcloud.")
 	pflag.Parse()
 
 	if len(rawURL) == 0 {


### PR DESCRIPTION
Command line arguments are visible by other processes. Leaking credentials
for an account with administrative privileges might be undesirable in
some setups. Therefore, we now allow URL, username and password to be
given by using the following environment variables: NEXTCLOUD_SERVERINFO_URL,
NEXTCLOUD_USERNAME, NEXTCLOUD_PASSWORD.