### PR TITLE
Unify configuration options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 run.sh
 nextcloud-exporter
+config.yml

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ There are three methods of configuring the nextcloud-exporter (higher methods ta
 
 All settings can also be specified through environment variables:
 
-    Environment variable | Flag equivalent
------------------------: | :--------------
-NEXTCLOUD_LISTEN_ADDRESS | --addr
-NEXTCLOUD_PASSWORD       | --password
-NEXTCLOUD_TIMEOUT        | --timeout 
-NEXTCLOUD_SERVERINFO_URL | --url
-NEXTCLOUD_USERNAME       | --username
+|       Environment variable | Flag equivalent |
+| -------------------------: | :-------------- |
+| `NEXTCLOUD_LISTEN_ADDRESS` | --addr          |
+| `NEXTCLOUD_PASSWORD`       | --password      |
+| `NEXTCLOUD_TIMEOUT`        | --timeout       |
+| `NEXTCLOUD_SERVERINFO_URL` | --url           |
+| `NEXTCLOUD_USERNAME`       | --username      |
 
 #### Configuration file
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ username: "example"
 
 ### Password file
 
-Optionally the password can be read from a separate file instead of directly from the input methods above. This can be achieved by setting the password to the path of the password file prefixed with an "@":
+Optionally the password can be read from a separate file instead of directly from the input methods above. This can be achieved by setting the password to the path of the password file prefixed with an "@", for example:
 
 ```bash
-$ nextcloud-exporter -c config.yml -p @/path/to/passwordfile
+$ nextcloud-exporter -c config-without-password.yml -p @/path/to/passwordfile
 ```
 
 ## Other information

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ To access the serverinfo API you will need the credentials of an admin user. It 
 
 ```plain
 $ nextcloud-exporter --help
-Usage of nextcloud-exporter:
-  -a, --addr string        Address to listen on for connections. (default ":9205")
-  -p, --password string    Password for connecting to nextcloud.
-  -t, --timeout duration   Timeout for getting server info document. (default 5s)
-  -l, --url string         URL to nextcloud serverinfo page.
-  -u, --username string    Username for connecting to nextcloud.
+Usage of ./result/bin/nextcloud-exporter:
+  -a, --addr string            Address to listen on for connections. (default ":9205")
+  -p, --password string        Password for connecting to nextcloud.
+      --password-file string   File containing the password for connecting to nextcloud.
+  -t, --timeout duration       Timeout for getting server info document. (default 5s)
+  -l, --url string             URL to nextcloud serverinfo page.
+  -u, --username string        Username for connecting to nextcloud.
 ```
 
 Some settings can also be specified through environment variables:
@@ -33,6 +34,7 @@ Name                     | Description
 NEXTCLOUD_SERVERINFO_URL | URL to nextcloud serverinfo page
 NEXTCLOUD_USERNAME       | Username for connecting to nextcloud
 NEXTCLOUD_PASSWORD       | Password for connecting to nextcloud
+NEXTCLOUD_PASSWORD_FILE  | File containing the password for connecting to nextcloud
 
 Command line arguments take precedence over environment variables.
 

--- a/README.md
+++ b/README.md
@@ -18,27 +18,72 @@ To access the serverinfo API you will need the credentials of an admin user. It 
 
 ```plain
 $ nextcloud-exporter --help
-Usage of ./result/bin/nextcloud-exporter:
-  -a, --addr string            Address to listen on for connections. (default ":9205")
-  -p, --password string        Password for connecting to nextcloud.
-      --password-file string   File containing the password for connecting to nextcloud.
-  -t, --timeout duration       Timeout for getting server info document. (default 5s)
-  -l, --url string             URL to nextcloud serverinfo page.
-  -u, --username string        Username for connecting to nextcloud.
+  Usage of nextcloud-exporter:
+    -a, --addr string          Address to listen on for connections. (default ":9205")
+    -c, --config-file string   Path to YAML configuration file.
+    -p, --password string      Password for connecting to Nextcloud.
+    -t, --timeout duration     Timeout for getting server info document. (default 5s)
+    -l, --url string           URL to Nextcloud serverinfo page.
+    -u, --username string      Username for connecting to Nextcloud.
 ```
 
-Some settings can also be specified through environment variables:
-
-Name                     | Description
--------------------------|-------------------------------------
-NEXTCLOUD_SERVERINFO_URL | URL to nextcloud serverinfo page
-NEXTCLOUD_USERNAME       | Username for connecting to nextcloud
-NEXTCLOUD_PASSWORD       | Password for connecting to nextcloud
-NEXTCLOUD_PASSWORD_FILE  | File containing the password for connecting to nextcloud
-
-Command line arguments take precedence over environment variables.
-
 After starting the server will offer the metrics on the `/metrics` endpoint, which can be used as a target for prometheus.
+
+### Configuration methods
+
+There are three methods of configuring the nextcloud-exporter (higher methods take precedence over lower ones):
+
+- Environment variables
+- Configuration file
+- Command-line parameters
+
+#### Environment variables
+
+All settings can also be specified through environment variables:
+
+    Environment variable | Flag equivalent
+-----------------------: | :--------------
+NEXTCLOUD_LISTEN_ADDRESS | --addr
+NEXTCLOUD_PASSWORD       | --password
+NEXTCLOUD_TIMEOUT        | --timeout 
+NEXTCLOUD_SERVERINFO_URL | --url
+NEXTCLOUD_USERNAME       | --username
+
+#### Configuration file
+
+The `--config-file` option can be used to read the configuration options from a YAML file:
+
+```yaml
+listenAddress: ":9205"
+password: "example"
+timeout: "5s"
+infoUrl: "https://example.com"
+username: "example"
+```
+
+### Password file
+
+Optionally the password can be read from a separate file instead of directly from the input methods above. This can be achieved by setting the password to the path of the password file prefixed with an "@":
+
+```bash
+$ nextcloud-exporter -c config.yml -p @/path/to/passwordfile
+```
+
+## Other information
+
+### Info URL
+
+The exporter reads the metrics from the Nextcloud server using its "serverinfo" API. You can find the URL of this API in the administrator settings in the "Monitoring" section. It should look something like this:
+
+```plain
+https://example.com/ocs/v2.php/apps/serverinfo/api/v1/info
+```
+
+When you do not specify a path on the `--url` parameter then the default path will be added automatically.
+
+If you open this URL in a browser you should see an XML structure with the information that will be used by the exporter.
+
+### Scrape configuration
 
 The exporter will query the nextcloud server every time it is scraped by prometheus. If you want to reduce load on the nextcloud server you need to change the scrape interval accordingly:
 
@@ -49,13 +94,3 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9205']
 ```
-
-### Info URL
-
-The exporter reads the metrics from the Nextcloud server using its "serverinfo" API. You can find the URL of this API in the administrator settings in the "Monitoring" section. It should look something like this:
-
-```plain
-https://example.com/ocs/v2.php/apps/serverinfo/api/v1/info
-```
-
-If you open this URL in a browser you should see an XML structure with the information that will be used by the exporter.

--- a/config.go
+++ b/config.go
@@ -11,6 +11,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const (
+	defaultPath = "/ocs/v2.php/apps/serverinfo/api/v1/info"
+)
+
 type config struct {
 	ListenAddr string
 	Timeout    time.Duration
@@ -82,6 +86,10 @@ func convertConfig(raw rawConfig) (config, error) {
 		return config{}, fmt.Errorf("info URL is not valid: %s", err)
 	}
 	result.InfoURL = infoURL
+
+	if result.InfoURL.Path == "" {
+		result.InfoURL.Path = defaultPath
+	}
 
 	if strings.HasPrefix(result.Password, "@") {
 		fileName := strings.TrimPrefix(result.Password, "@")

--- a/config.go
+++ b/config.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+type config struct {
+	ListenAddr   string
+	Timeout      time.Duration
+	InfoURL      *url.URL
+	Username     string
+	Password     string
+	PasswordFile string
+}
+
+func parseConfig() (config, error) {
+	result := config{
+		ListenAddr:   ":9205",
+		Timeout:      5 * time.Second,
+		Username:     os.Getenv("NEXTCLOUD_USERNAME"),
+		Password:     os.Getenv("NEXTCLOUD_PASSWORD"),
+		PasswordFile: os.Getenv("NEXTCLOUD_PASSWORD_FILE"),
+	}
+
+	rawURL := os.Getenv("NEXTCLOUD_SERVERINFO_URL");
+	pflag.StringVarP(&result.ListenAddr, "addr", "a", result.ListenAddr, "Address to listen on for connections.")
+	pflag.DurationVarP(&result.Timeout, "timeout", "t", result.Timeout, "Timeout for getting server info document.")
+	pflag.StringVarP(&rawURL, "url", "l", rawURL, "URL to nextcloud serverinfo page.")
+	pflag.StringVarP(&result.Username, "username", "u", result.Username, "Username for connecting to nextcloud.")
+	pflag.StringVarP(&result.Password, "password", "p", result.Password, "Password for connecting to nextcloud.")
+	pflag.StringVar(&result.PasswordFile, "password-file", result.PasswordFile, "File containing the password for connecting to nextcloud.")
+	pflag.Parse()
+
+	if len(rawURL) == 0 {
+		return result, errors.New("need to provide an info URL")
+	}
+
+	infoURL, err := url.Parse(rawURL)
+	if err != nil {
+		return result, fmt.Errorf("info URL is not valid: %s", err)
+	}
+	result.InfoURL = infoURL
+
+	if len(result.Username) == 0 {
+		return result, errors.New("need to provide a username")
+	}
+
+	if len(result.PasswordFile) != 0 {
+		fd, err := os.Open(result.PasswordFile)
+		if err != nil {
+			return result, fmt.Errorf("could not open password file: %s", err)
+		}
+		defer fd.Close()
+
+		s := bufio.NewScanner(fd)
+		if s.Scan() {
+			result.Password = s.Text()
+			return result, nil
+		} else {
+			return result, errors.New("read empty password from given password file")
+		}
+	}
+	if len(result.Password) == 0 {
+		return result, errors.New("need to provide a password")
+	}
+
+	return result, nil
+}

--- a/config.go
+++ b/config.go
@@ -6,27 +6,26 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
 )
 
 type config struct {
-	ListenAddr   string
-	Timeout      time.Duration
-	InfoURL      *url.URL
-	Username     string
-	Password     string
-	PasswordFile string
+	ListenAddr string
+	Timeout    time.Duration
+	InfoURL    *url.URL
+	Username   string
+	Password   string
 }
 
 func parseConfig() (config, error) {
 	result := config{
-		ListenAddr:   ":9205",
-		Timeout:      5 * time.Second,
-		Username:     os.Getenv("NEXTCLOUD_USERNAME"),
-		Password:     os.Getenv("NEXTCLOUD_PASSWORD"),
-		PasswordFile: os.Getenv("NEXTCLOUD_PASSWORD_FILE"),
+		ListenAddr: ":9205",
+		Timeout:    5 * time.Second,
+		Username:   os.Getenv("NEXTCLOUD_USERNAME"),
+		Password:   os.Getenv("NEXTCLOUD_PASSWORD"),
 	}
 
 	rawURL := os.Getenv("NEXTCLOUD_SERVERINFO_URL");
@@ -35,7 +34,6 @@ func parseConfig() (config, error) {
 	pflag.StringVarP(&rawURL, "url", "l", rawURL, "URL to nextcloud serverinfo page.")
 	pflag.StringVarP(&result.Username, "username", "u", result.Username, "Username for connecting to nextcloud.")
 	pflag.StringVarP(&result.Password, "password", "p", result.Password, "Password for connecting to nextcloud.")
-	pflag.StringVar(&result.PasswordFile, "password-file", result.PasswordFile, "File containing the password for connecting to nextcloud.")
 	pflag.Parse()
 
 	if len(rawURL) == 0 {
@@ -52,8 +50,9 @@ func parseConfig() (config, error) {
 		return result, errors.New("need to provide a username")
 	}
 
-	if len(result.PasswordFile) != 0 {
-		password, err := readPasswordFile(result.PasswordFile)
+	if strings.HasPrefix(result.Password, "@") {
+		fileName := strings.TrimPrefix(result.Password, "@")
+		password, err := readPasswordFile(fileName)
 		if err != nil {
 			return result, fmt.Errorf("can not read password file: %s", err)
 		}

--- a/config.go
+++ b/config.go
@@ -5,14 +5,23 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v2"
 )
 
 const (
 	defaultPath = "/ocs/v2.php/apps/serverinfo/api/v1/info"
+
+	envPrefix        = "NEXTCLOUD_"
+	envListenAddress = envPrefix + "LISTEN_ADDRESS"
+	envTimeout       = envPrefix + "TIMEOUT"
+	envInfoURL       = envPrefix + "SERVERINFO_URL"
+	envUsername      = envPrefix + "USERNAME"
+	envPassword      = envPrefix + "PASSWORD"
 )
 
 type config struct {
@@ -32,10 +41,25 @@ type rawConfig struct {
 }
 
 func parseConfig() (config, error) {
-	raw := loadConfigFromFlags()
+	raw, configFile := loadConfigFromFlags()
+
+	if configFile != "" {
+		rawFile, err := loadConfigFromFile(configFile)
+		if err != nil {
+			return config{}, fmt.Errorf("error reading configuration file: %s", err)
+		}
+
+		raw = mergeConfig(raw, rawFile)
+	}
+
+	env, err := loadConfigFromEnv()
+	if err != nil {
+		return config{}, fmt.Errorf("error reading environment variables: %s", err)
+	}
+	raw = mergeConfig(raw, env)
 
 	if len(raw.InfoURL) == 0 {
-		return config{}, errors.New("need to provide an info URL")
+		return config{}, errors.New("need to set an info URL")
 	}
 
 	result, err := convertConfig(raw)
@@ -61,16 +85,17 @@ func defaultConfig() config {
 	}
 }
 
-func loadConfigFromFlags() (result rawConfig) {
+func loadConfigFromFlags() (result rawConfig, configFile string) {
 	defaults := defaultConfig()
+	pflag.StringVarP(&configFile, "config-file", "c", "", "Path to YAML configuration file.")
 	pflag.StringVarP(&result.ListenAddr, "addr", "a", defaults.ListenAddr, "Address to listen on for connections.")
 	pflag.DurationVarP(&result.Timeout, "timeout", "t", defaults.Timeout, "Timeout for getting server info document.")
-	pflag.StringVarP(&result.InfoURL, "url", "l", "", "URL to nextcloud serverinfo page.")
-	pflag.StringVarP(&result.Username, "username", "u", defaults.Username, "Username for connecting to nextcloud.")
-	pflag.StringVarP(&result.Password, "password", "p", defaults.Password, "Password for connecting to nextcloud.")
+	pflag.StringVarP(&result.InfoURL, "url", "l", "", "URL to Nextcloud serverinfo page.")
+	pflag.StringVarP(&result.Username, "username", "u", defaults.Username, "Username for connecting to Nextcloud.")
+	pflag.StringVarP(&result.Password, "password", "p", defaults.Password, "Password for connecting to Nextcloud.")
 	pflag.Parse()
 
-	return result
+	return result, configFile
 }
 
 func convertConfig(raw rawConfig) (config, error) {
@@ -102,6 +127,65 @@ func convertConfig(raw rawConfig) (config, error) {
 	}
 
 	return result, nil
+}
+
+func loadConfigFromFile(fileName string) (rawConfig, error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return rawConfig{}, err
+	}
+
+	var result rawConfig
+	if err := yaml.NewDecoder(file).Decode(&result); err != nil {
+		return rawConfig{}, err
+	}
+
+	return result, nil
+}
+
+func loadConfigFromEnv() (rawConfig, error) {
+	result := rawConfig{
+		ListenAddr: os.Getenv(envListenAddress),
+		InfoURL:    os.Getenv(envInfoURL),
+		Username:   os.Getenv(envUsername),
+		Password:   os.Getenv(envPassword),
+	}
+
+	if raw, ok := os.LookupEnv(envTimeout); ok {
+		value, err := time.ParseDuration(raw)
+		if err != nil {
+			return rawConfig{}, err
+		}
+
+		result.Timeout = value
+	}
+
+	return result, nil
+}
+
+func mergeConfig(base, override rawConfig) rawConfig {
+	result := base
+	if override.ListenAddr != "" {
+		result.ListenAddr = override.ListenAddr
+	}
+
+	if override.InfoURL != "" {
+		result.InfoURL = override.InfoURL
+	}
+
+	if override.Username != "" {
+		result.Username = override.Username
+	}
+
+	if override.Password != "" {
+		result.Password = override.Password
+	}
+
+	if override.Timeout != 0 {
+		result.Timeout = override.Timeout
+	}
+
+	return result
 }
 
 func readPasswordFile(fileName string) (string, error) {

--- a/config.go
+++ b/config.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"time"
@@ -53,23 +53,25 @@ func parseConfig() (config, error) {
 	}
 
 	if len(result.PasswordFile) != 0 {
-		fd, err := os.Open(result.PasswordFile)
+		password, err := readPasswordFile(result.PasswordFile)
 		if err != nil {
-			return result, fmt.Errorf("could not open password file: %s", err)
+			return result, fmt.Errorf("can not read password file: %s", err)
 		}
-		defer fd.Close()
 
-		s := bufio.NewScanner(fd)
-		if s.Scan() {
-			result.Password = s.Text()
-			return result, nil
-		} else {
-			return result, errors.New("read empty password from given password file")
-		}
+		result.Password = password
 	}
 	if len(result.Password) == 0 {
 		return result, errors.New("need to provide a password")
 	}
 
 	return result, nil
+}
+
+func readPasswordFile(fileName string) (string, error) {
+	bytes, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/sys v0.0.0-20190812172437-4e8604ab3aff // indirect
+	gopkg.in/yaml.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -71,5 +71,7 @@ golang.org/x/sys v0.0.0-20190812172437-4e8604ab3aff h1:u5LtynOOWSPG+jkEa3Y4ATlQ0
 golang.org/x/sys v0.0.0-20190812172437-4e8604ab3aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -1,82 +1,12 @@
 package main
 
 import (
-	"bufio"
-	"errors"
-	"fmt"
 	"log"
 	"net/http"
-	"net/url"
-	"os"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/spf13/pflag"
 )
-
-type config struct {
-	ListenAddr   string
-	Timeout      time.Duration
-	InfoURL      *url.URL
-	Username     string
-	Password     string
-	PasswordFile string
-}
-
-func parseConfig() (config, error) {
-	result := config{
-		ListenAddr:   ":9205",
-		Timeout:      5 * time.Second,
-		Username:     os.Getenv("NEXTCLOUD_USERNAME"),
-		Password:     os.Getenv("NEXTCLOUD_PASSWORD"),
-		PasswordFile: os.Getenv("NEXTCLOUD_PASSWORD_FILE"),
-	}
-
-	rawURL := os.Getenv("NEXTCLOUD_SERVERINFO_URL");
-	pflag.StringVarP(&result.ListenAddr, "addr", "a", result.ListenAddr, "Address to listen on for connections.")
-	pflag.DurationVarP(&result.Timeout, "timeout", "t", result.Timeout, "Timeout for getting server info document.")
-	pflag.StringVarP(&rawURL, "url", "l", rawURL, "URL to nextcloud serverinfo page.")
-	pflag.StringVarP(&result.Username, "username", "u", result.Username, "Username for connecting to nextcloud.")
-	pflag.StringVarP(&result.Password, "password", "p", result.Password, "Password for connecting to nextcloud.")
-	pflag.StringVar(&result.PasswordFile, "password-file", result.PasswordFile, "File containing the password for connecting to nextcloud.")
-	pflag.Parse()
-
-	if len(rawURL) == 0 {
-		return result, errors.New("need to provide an info URL")
-	}
-
-	infoURL, err := url.Parse(rawURL)
-	if err != nil {
-		return result, fmt.Errorf("info URL is not valid: %s", err)
-	}
-	result.InfoURL = infoURL
-
-	if len(result.Username) == 0 {
-		return result, errors.New("need to provide a username")
-	}
-
-	if len(result.PasswordFile) != 0 {
-		fd, err := os.Open(result.PasswordFile)
-		if err != nil {
-			return result, fmt.Errorf("could not open password file: %s", err)
-		}
-		defer fd.Close()
-
-		s := bufio.NewScanner(fd)
-		if s.Scan() {
-			result.Password = s.Text()
-			return result, nil
-		} else {
-			return result, errors.New("read empty password from given password file")
-		}
-	}
-	if len(result.Password) == 0 {
-		return result, errors.New("need to provide a password")
-	}
-
-	return result, nil
-}
 
 func main() {
 	config, err := parseConfig()

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"log"
@@ -15,19 +16,21 @@ import (
 )
 
 type config struct {
-	ListenAddr string
-	Timeout    time.Duration
-	InfoURL    *url.URL
-	Username   string
-	Password   string
+	ListenAddr   string
+	Timeout      time.Duration
+	InfoURL      *url.URL
+	Username     string
+	Password     string
+	PasswordFile string
 }
 
 func parseConfig() (config, error) {
 	result := config{
-		ListenAddr: ":9205",
-		Timeout:    5 * time.Second,
-		Username:   os.Getenv("NEXTCLOUD_USERNAME"),
-		Password:   os.Getenv("NEXTCLOUD_PASSWORD"),
+		ListenAddr:   ":9205",
+		Timeout:      5 * time.Second,
+		Username:     os.Getenv("NEXTCLOUD_USERNAME"),
+		Password:     os.Getenv("NEXTCLOUD_PASSWORD"),
+		PasswordFile: os.Getenv("NEXTCLOUD_PASSWORD_FILE"),
 	}
 
 	rawURL := os.Getenv("NEXTCLOUD_SERVERINFO_URL");
@@ -36,6 +39,7 @@ func parseConfig() (config, error) {
 	pflag.StringVarP(&rawURL, "url", "l", rawURL, "URL to nextcloud serverinfo page.")
 	pflag.StringVarP(&result.Username, "username", "u", result.Username, "Username for connecting to nextcloud.")
 	pflag.StringVarP(&result.Password, "password", "p", result.Password, "Password for connecting to nextcloud.")
+	pflag.StringVar(&result.PasswordFile, "password-file", result.PasswordFile, "File containing the password for connecting to nextcloud.")
 	pflag.Parse()
 
 	if len(rawURL) == 0 {
@@ -52,6 +56,21 @@ func parseConfig() (config, error) {
 		return result, errors.New("need to provide a username")
 	}
 
+	if len(result.PasswordFile) != 0 {
+		fd, err := os.Open(result.PasswordFile)
+		if err != nil {
+			return result, fmt.Errorf("could not open password file: %s", err)
+		}
+		defer fd.Close()
+
+		s := bufio.NewScanner(fd)
+		if s.Scan() {
+			result.Password = s.Text()
+			return result, nil
+		} else {
+			return result, errors.New("read empty password from given password file")
+		}
+	}
 	if len(result.Password) == 0 {
 		return result, errors.New("need to provide a password")
 	}


### PR DESCRIPTION
I added an option to specify a password file, which only the exporter needs to be able to read, to avoid having users with access to the service configuration of the exporter (e.g. a systemd unit file) read the password for the nextcloud user (which has admin capabilities).