### PR TITLE
Switch Docker builder image to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.13.1 AS builder
+FROM golang:1.13.10-alpine AS builder
 
-RUN apt-get update && apt-get install -y upx
+RUN apk add --no-cache ca-certificates upx
 
 WORKDIR /build
 


### PR DESCRIPTION
- contains fixes for CVE-2019-17596 and CVE-2020-7919
- updates ca-certificates