### PR TITLE
Refactor to use server URL instead

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 GO ?= go
 GO_CMD := CGO_ENABLED=0 $(GO)
-VERSION := $(shell git describe --tags HEAD)
+VERSION := $(shell git describe --tags --broken)
 GIT_COMMIT := $(shell git rev-parse HEAD)
 
 all: test build-binary

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GIT_COMMIT := $(shell git rev-parse HEAD)
 all: test build-binary
 
 test:
-	$(GO_CMD) test ./...
+	$(GO_CMD) test -cover ./...
 
 build-binary:
 	$(GO_CMD) build -tags netgo -ldflags "-w -X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT)" -o nextcloud-exporter .

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ To access the serverinfo API you will need the credentials of an admin user. It 
 
 ```plain
 $ nextcloud-exporter --help
-  Usage of nextcloud-exporter:
-    -a, --addr string          Address to listen on for connections. (default ":9205")
-    -c, --config-file string   Path to YAML configuration file.
-    -p, --password string      Password for connecting to Nextcloud.
-    -t, --timeout duration     Timeout for getting server info document. (default 5s)
-    -l, --url string           URL to Nextcloud serverinfo page.
-    -u, --username string      Username for connecting to Nextcloud.
+Usage of nextcloud-exporter:
+  -a, --addr string          Address to listen on for connections. (default ":9205")
+  -c, --config-file string   Path to YAML configuration file.
+  -p, --password string      Password for connecting to Nextcloud.
+  -s, --server string        URL to Nextcloud server.
+  -t, --timeout duration     Timeout for getting server info document. (default 5s)
+  -u, --username string      Username for connecting to Nextcloud.
 ```
 
 After starting the server will offer the metrics on the `/metrics` endpoint, which can be used as a target for prometheus.
@@ -41,13 +41,13 @@ There are three methods of configuring the nextcloud-exporter (higher methods ta
 
 All settings can also be specified through environment variables:
 
-|       Environment variable | Flag equivalent |
+|    Environment variable    | Flag equivalent |
 | -------------------------: | :-------------- |
 | `NEXTCLOUD_LISTEN_ADDRESS` | --addr          |
-| `NEXTCLOUD_PASSWORD`       | --password      |
-| `NEXTCLOUD_TIMEOUT`        | --timeout       |
-| `NEXTCLOUD_SERVERINFO_URL` | --url           |
-| `NEXTCLOUD_USERNAME`       | --username      |
+|       `NEXTCLOUD_PASSWORD` | --password      |
+|        `NEXTCLOUD_TIMEOUT` | --timeout       |
+|         `NEXTCLOUD_SERVER` | --server        |
+|       `NEXTCLOUD_USERNAME` | --username      |
 
 #### Configuration file
 
@@ -57,7 +57,7 @@ The `--config-file` option can be used to read the configuration options from a 
 listenAddress: ":9205"
 password: "example"
 timeout: "5s"
-infoUrl: "https://example.com"
+server: "https://example.com"
 username: "example"
 ```
 
@@ -66,7 +66,7 @@ username: "example"
 Optionally the password can be read from a separate file instead of directly from the input methods above. This can be achieved by setting the password to the path of the password file prefixed with an "@", for example:
 
 ```bash
-$ nextcloud-exporter -c config-without-password.yml -p @/path/to/passwordfile
+nextcloud-exporter -c config-without-password.yml -p @/path/to/passwordfile
 ```
 
 ## Other information
@@ -79,7 +79,7 @@ The exporter reads the metrics from the Nextcloud server using its "serverinfo" 
 https://example.com/ocs/v2.php/apps/serverinfo/api/v1/info
 ```
 
-When you do not specify a path on the `--url` parameter then the default path will be added automatically.
+The path will be automatically added to the server URL you provide, so in the above example setting `--server https://example.com` would be sufficient.
 
 If you open this URL in a browser you should see an XML structure with the information that will be used by the exporter.
 

--- a/collector.go
+++ b/collector.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -63,7 +62,7 @@ var (
 )
 
 type nextcloudCollector struct {
-	infoURL            *url.URL
+	infoURL            string
 	username           string
 	password           string
 	client             *http.Client
@@ -73,7 +72,7 @@ type nextcloudCollector struct {
 	scrapeErrorsMetric prometheus.Counter
 }
 
-func newCollector(infoURL *url.URL, username, password string, timeout time.Duration, userAgent string) *nextcloudCollector {
+func newCollector(infoURL, username, password string, timeout time.Duration, userAgent string) *nextcloudCollector {
 	return &nextcloudCollector{
 		infoURL:  infoURL,
 		username: username,
@@ -125,7 +124,7 @@ func (c *nextcloudCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (c *nextcloudCollector) collectNextcloud(ch chan<- prometheus.Metric) error {
-	req, err := http.NewRequest(http.MethodGet, c.infoURL.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, c.infoURL, nil)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/xperimental/nextcloud-exporter
 go 1.13
 
 require (
+	github.com/google/go-cmp v0.4.0
 	github.com/prometheus/client_golang v1.6.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.3.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,7 +49,7 @@ func Get() (Config, error) {
 func parseConfig(args []string, envFunc func(string) string) (Config, error) {
 	raw, configFile, err := loadConfigFromFlags(args)
 	if err != nil {
-		return Config{}, err
+		return Config{}, fmt.Errorf("error parsing flags: %s", err)
 	}
 
 	if configFile != "" {
@@ -208,5 +208,5 @@ func readPasswordFile(fileName string) (string, error) {
 		return "", err
 	}
 
-	return string(bytes), nil
+	return strings.TrimSuffix(string(bytes), "\n"), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -14,29 +13,19 @@ import (
 )
 
 const (
-	defaultPath = "/ocs/v2.php/apps/serverinfo/api/v1/info"
-
 	envPrefix        = "NEXTCLOUD_"
 	envListenAddress = envPrefix + "LISTEN_ADDRESS"
 	envTimeout       = envPrefix + "TIMEOUT"
-	envInfoURL       = envPrefix + "SERVERINFO_URL"
+	envServerURL     = envPrefix + "SERVER"
 	envUsername      = envPrefix + "USERNAME"
 	envPassword      = envPrefix + "PASSWORD"
 )
 
 // Config contains the configuration options for nextcloud-exporter.
 type Config struct {
-	ListenAddr string
-	Timeout    time.Duration
-	InfoURL    *url.URL
-	Username   string
-	Password   string
-}
-
-type rawConfig struct {
 	ListenAddr string        `yaml:"listenAddress"`
 	Timeout    time.Duration `yaml:"timeout"`
-	InfoURL    string        `yaml:"infoUrl"`
+	ServerURL  string        `yaml:"server"`
 	Username   string        `yaml:"username"`
 	Password   string        `yaml:"password"`
 }
@@ -47,7 +36,7 @@ func Get() (Config, error) {
 }
 
 func parseConfig(args []string, envFunc func(string) string) (Config, error) {
-	raw, configFile, err := loadConfigFromFlags(args)
+	result, configFile, err := loadConfigFromFlags(args)
 	if err != nil {
 		return Config{}, fmt.Errorf("error parsing flags: %s", err)
 	}
@@ -58,22 +47,27 @@ func parseConfig(args []string, envFunc func(string) string) (Config, error) {
 			return Config{}, fmt.Errorf("error reading configuration file: %s", err)
 		}
 
-		raw = mergeConfig(raw, rawFile)
+		result = mergeConfig(result, rawFile)
 	}
 
 	env, err := loadConfigFromEnv(envFunc)
 	if err != nil {
 		return Config{}, fmt.Errorf("error reading environment variables: %s", err)
 	}
-	raw = mergeConfig(raw, env)
+	result = mergeConfig(result, env)
 
-	if len(raw.InfoURL) == 0 {
-		return Config{}, errors.New("need to set an info URL")
+	if strings.HasPrefix(result.Password, "@") {
+		fileName := strings.TrimPrefix(result.Password, "@")
+		password, err := readPasswordFile(fileName)
+		if err != nil {
+			return Config{}, fmt.Errorf("can not read password file: %s", err)
+		}
+
+		result.Password = password
 	}
 
-	result, err := convertConfig(raw)
-	if err != nil {
-		return Config{}, err
+	if len(result.ServerURL) == 0 {
+		return Config{}, errors.New("need to set a server URL")
 	}
 
 	if len(result.Username) == 0 {
@@ -94,73 +88,42 @@ func defaultConfig() Config {
 	}
 }
 
-func loadConfigFromFlags(args []string) (result rawConfig, configFile string, err error) {
+func loadConfigFromFlags(args []string) (result Config, configFile string, err error) {
 	defaults := defaultConfig()
 
 	flags := pflag.NewFlagSet(args[0], pflag.ContinueOnError)
 	flags.StringVarP(&configFile, "config-file", "c", "", "Path to YAML configuration file.")
 	flags.StringVarP(&result.ListenAddr, "addr", "a", defaults.ListenAddr, "Address to listen on for connections.")
 	flags.DurationVarP(&result.Timeout, "timeout", "t", defaults.Timeout, "Timeout for getting server info document.")
-	flags.StringVarP(&result.InfoURL, "url", "l", "", "URL to Nextcloud serverinfo page.")
+	flags.StringVarP(&result.ServerURL, "server", "s", "", "URL to Nextcloud server.")
 	flags.StringVarP(&result.Username, "username", "u", defaults.Username, "Username for connecting to Nextcloud.")
 	flags.StringVarP(&result.Password, "password", "p", defaults.Password, "Password for connecting to Nextcloud.")
 
 	if err := flags.Parse(args[1:]); err != nil {
-		return rawConfig{}, "", err
+		return Config{}, "", err
 	}
 
 	return result, configFile, nil
 }
 
-func convertConfig(raw rawConfig) (Config, error) {
-	result := Config{
-		ListenAddr: raw.ListenAddr,
-		Timeout:    raw.Timeout,
-		Username:   raw.Username,
-		Password:   raw.Password,
-	}
-
-	infoURL, err := url.Parse(raw.InfoURL)
-	if err != nil {
-		return Config{}, fmt.Errorf("info URL is not valid: %s", err)
-	}
-	result.InfoURL = infoURL
-
-	if result.InfoURL.Path == "" {
-		result.InfoURL.Path = defaultPath
-	}
-
-	if strings.HasPrefix(result.Password, "@") {
-		fileName := strings.TrimPrefix(result.Password, "@")
-		password, err := readPasswordFile(fileName)
-		if err != nil {
-			return Config{}, fmt.Errorf("can not read password file: %s", err)
-		}
-
-		result.Password = password
-	}
-
-	return result, nil
-}
-
-func loadConfigFromFile(fileName string) (rawConfig, error) {
+func loadConfigFromFile(fileName string) (Config, error) {
 	file, err := os.Open(fileName)
 	if err != nil {
-		return rawConfig{}, err
+		return Config{}, err
 	}
 
-	var result rawConfig
+	var result Config
 	if err := yaml.NewDecoder(file).Decode(&result); err != nil {
-		return rawConfig{}, err
+		return Config{}, err
 	}
 
 	return result, nil
 }
 
-func loadConfigFromEnv(getEnv func(string) string) (rawConfig, error) {
-	result := rawConfig{
+func loadConfigFromEnv(getEnv func(string) string) (Config, error) {
+	result := Config{
 		ListenAddr: getEnv(envListenAddress),
-		InfoURL:    getEnv(envInfoURL),
+		ServerURL:  getEnv(envServerURL),
 		Username:   getEnv(envUsername),
 		Password:   getEnv(envPassword),
 	}
@@ -168,7 +131,7 @@ func loadConfigFromEnv(getEnv func(string) string) (rawConfig, error) {
 	if raw := getEnv(envTimeout); raw != "" {
 		value, err := time.ParseDuration(raw)
 		if err != nil {
-			return rawConfig{}, err
+			return Config{}, err
 		}
 
 		result.Timeout = value
@@ -177,14 +140,14 @@ func loadConfigFromEnv(getEnv func(string) string) (rawConfig, error) {
 	return result, nil
 }
 
-func mergeConfig(base, override rawConfig) rawConfig {
+func mergeConfig(base, override Config) Config {
 	result := base
 	if override.ListenAddr != "" {
 		result.ListenAddr = override.ListenAddr
 	}
 
-	if override.InfoURL != "" {
-		result.InfoURL = override.InfoURL
+	if override.ServerURL != "" {
+		result.ServerURL = override.ServerURL
 	}
 
 	if override.Username != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,241 @@
+package config
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func testEnv(env map[string]string) func(string) string {
+	return func(key string) string {
+		return env[key]
+	}
+}
+
+func mustURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}
+
+var compareErrors = cmp.Comparer(func(a, b error) bool {
+	aE := a.Error()
+	bE := b.Error()
+
+	return aE == bE
+})
+
+func TestConfig(t *testing.T) {
+	defaults := defaultConfig()
+	tt := []struct {
+		desc       string
+		args       []string
+		env        map[string]string
+		wantErr    error
+		wantConfig Config
+	}{
+		{
+			desc: "flags",
+			args: []string{
+				"test",
+				"--addr",
+				"127.0.0.1:9205",
+				"--timeout",
+				"30s",
+				"--url",
+				"http://localhost",
+				"--username",
+				"testuser",
+				"--password",
+				"testpass",
+			},
+			env:     map[string]string{},
+			wantErr: nil,
+			wantConfig: Config{
+				ListenAddr: "127.0.0.1:9205",
+				Timeout:    30 * time.Second,
+				InfoURL:    mustURL("http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info"),
+				Username:   "testuser",
+				Password:   "testpass",
+			},
+		},
+		{
+			desc: "password from file",
+			args: []string{
+				"test",
+				"--url",
+				"http://localhost",
+				"--username",
+				"testuser",
+				"--password",
+				"@testdata/password",
+			},
+			env:     map[string]string{},
+			wantErr: nil,
+			wantConfig: Config{
+				ListenAddr: defaults.ListenAddr,
+				Timeout:    defaults.Timeout,
+				InfoURL:    mustURL("http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info"),
+				Username:   "testuser",
+				Password:   "testpass",
+			},
+		},
+		{
+			desc: "config from file",
+			args: []string{
+				"test",
+				"--config-file",
+				"testdata/all.yml",
+			},
+			env:     map[string]string{},
+			wantErr: nil,
+			wantConfig: Config{
+				ListenAddr: "127.0.0.10:9205",
+				Timeout:    10 * time.Second,
+				InfoURL:    mustURL("http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info"),
+				Username:   "testuser",
+				Password:   "testpass",
+			},
+		},
+		{
+			desc: "env config",
+			args: []string{
+				"test",
+			},
+			env: map[string]string{
+				envListenAddress: "127.0.0.11:9205",
+				envTimeout:       "15s",
+				envInfoURL:       "http://localhost",
+				envUsername:      "testuser",
+				envPassword:      "testpass",
+			},
+			wantErr: nil,
+			wantConfig: Config{
+				ListenAddr: "127.0.0.11:9205",
+				Timeout:    15 * time.Second,
+				InfoURL:    mustURL("http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info"),
+				Username:   "testuser",
+				Password:   "testpass",
+			},
+		},
+		{
+			desc: "minimal env",
+			args: []string{
+				"test",
+			},
+			env: map[string]string{
+				envInfoURL:  "http://localhost",
+				envUsername: "testuser",
+				envPassword: "testpass",
+			},
+			wantErr: nil,
+			wantConfig: Config{
+				ListenAddr: defaults.ListenAddr,
+				Timeout:    defaults.Timeout,
+				InfoURL:    mustURL("http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info"),
+				Username:   "testuser",
+				Password:   "testpass",
+			},
+		},
+		{
+			desc: "wrongflag",
+			args: []string{
+				"test",
+				"--unknown",
+			},
+			env:     map[string]string{},
+			wantErr: errors.New("error parsing flags: unknown flag: --unknown"),
+		},
+		{
+			desc: "no url",
+			args: []string{
+				"test",
+			},
+			env:     map[string]string{},
+			wantErr: errors.New("need to set an info URL"),
+		},
+		{
+			desc: "no username",
+			args: []string{
+				"test",
+				"--url",
+				"http://localhost",
+				"--password",
+				"testpass",
+			},
+			env:     map[string]string{},
+			wantErr: errors.New("need to provide a username"),
+		},
+		{
+			desc: "no password",
+			args: []string{
+				"test",
+				"--url",
+				"http://localhost",
+				"--username",
+				"testuser",
+			},
+			env:     map[string]string{},
+			wantErr: errors.New("need to provide a password"),
+		},
+		{
+			desc: "env wrong duration",
+			args: []string{
+				"test",
+			},
+			env: map[string]string{
+				"NEXTCLOUD_TIMEOUT": "unknown",
+			},
+			wantErr: errors.New("error reading environment variables: time: invalid duration unknown"),
+		},
+		{
+			desc: "password from file error",
+			args: []string{
+				"test",
+				"--url",
+				"http://localhost",
+				"--password",
+				"@testdata/notfound",
+			},
+			env:     map[string]string{},
+			wantErr: errors.New("can not read password file: open testdata/notfound: no such file or directory"),
+		},
+		{
+			desc: "config from file error",
+			args: []string{
+				"test",
+				"--config-file",
+				"testdata/notfound.yml",
+			},
+			env:     map[string]string{},
+			wantErr: errors.New("error reading configuration file: open testdata/notfound.yml: no such file or directory"),
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			config, err := parseConfig(tc.args, testEnv(tc.env))
+
+			if diff := cmp.Diff(err, tc.wantErr, compareErrors); diff != "" {
+				t.Errorf("error differs: -got +want\n%s", diff)
+			}
+
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(config, tc.wantConfig); diff != "" {
+				t.Errorf("config differs: -got +want\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,6 +104,23 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
+			desc: "config and password from file",
+			args: []string{
+				"test",
+				"--config-file",
+				"testdata/passwordfile.yml",
+			},
+			env:     map[string]string{},
+			wantErr: nil,
+			wantConfig: Config{
+				ListenAddr: "127.0.0.10:9205",
+				Timeout:    10 * time.Second,
+				ServerURL:  "http://localhost",
+				Username:   "testuser",
+				Password:   "testpass",
+			},
+		},
+		{
 			desc: "env config",
 			args: []string{
 				"test",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -48,7 +48,7 @@ func TestConfig(t *testing.T) {
 				"127.0.0.1:9205",
 				"--timeout",
 				"30s",
-				"--url",
+				"--server",
 				"http://localhost",
 				"--username",
 				"testuser",
@@ -60,7 +60,7 @@ func TestConfig(t *testing.T) {
 			wantConfig: Config{
 				ListenAddr: "127.0.0.1:9205",
 				Timeout:    30 * time.Second,
-				InfoURL:    mustURL("http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info"),
+				ServerURL:  "http://localhost",
 				Username:   "testuser",
 				Password:   "testpass",
 			},
@@ -69,7 +69,7 @@ func TestConfig(t *testing.T) {
 			desc: "password from file",
 			args: []string{
 				"test",
-				"--url",
+				"--server",
 				"http://localhost",
 				"--username",
 				"testuser",
@@ -81,7 +81,7 @@ func TestConfig(t *testing.T) {
 			wantConfig: Config{
 				ListenAddr: defaults.ListenAddr,
 				Timeout:    defaults.Timeout,
-				InfoURL:    mustURL("http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info"),
+				ServerURL:  "http://localhost",
 				Username:   "testuser",
 				Password:   "testpass",
 			},
@@ -98,7 +98,7 @@ func TestConfig(t *testing.T) {
 			wantConfig: Config{
 				ListenAddr: "127.0.0.10:9205",
 				Timeout:    10 * time.Second,
-				InfoURL:    mustURL("http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info"),
+				ServerURL:  "http://localhost",
 				Username:   "testuser",
 				Password:   "testpass",
 			},
@@ -111,7 +111,7 @@ func TestConfig(t *testing.T) {
 			env: map[string]string{
 				envListenAddress: "127.0.0.11:9205",
 				envTimeout:       "15s",
-				envInfoURL:       "http://localhost",
+				envServerURL:     "http://localhost",
 				envUsername:      "testuser",
 				envPassword:      "testpass",
 			},
@@ -119,7 +119,7 @@ func TestConfig(t *testing.T) {
 			wantConfig: Config{
 				ListenAddr: "127.0.0.11:9205",
 				Timeout:    15 * time.Second,
-				InfoURL:    mustURL("http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info"),
+				ServerURL:  "http://localhost",
 				Username:   "testuser",
 				Password:   "testpass",
 			},
@@ -130,15 +130,15 @@ func TestConfig(t *testing.T) {
 				"test",
 			},
 			env: map[string]string{
-				envInfoURL:  "http://localhost",
-				envUsername: "testuser",
-				envPassword: "testpass",
+				envServerURL: "http://localhost",
+				envUsername:  "testuser",
+				envPassword:  "testpass",
 			},
 			wantErr: nil,
 			wantConfig: Config{
 				ListenAddr: defaults.ListenAddr,
 				Timeout:    defaults.Timeout,
-				InfoURL:    mustURL("http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info"),
+				ServerURL:  "http://localhost",
 				Username:   "testuser",
 				Password:   "testpass",
 			},
@@ -158,13 +158,13 @@ func TestConfig(t *testing.T) {
 				"test",
 			},
 			env:     map[string]string{},
-			wantErr: errors.New("need to set an info URL"),
+			wantErr: errors.New("need to set a server URL"),
 		},
 		{
 			desc: "no username",
 			args: []string{
 				"test",
-				"--url",
+				"--server",
 				"http://localhost",
 				"--password",
 				"testpass",
@@ -176,7 +176,7 @@ func TestConfig(t *testing.T) {
 			desc: "no password",
 			args: []string{
 				"test",
-				"--url",
+				"--server",
 				"http://localhost",
 				"--username",
 				"testuser",
@@ -198,7 +198,7 @@ func TestConfig(t *testing.T) {
 			desc: "password from file error",
 			args: []string{
 				"test",
-				"--url",
+				"--server",
 				"http://localhost",
 				"--password",
 				"@testdata/notfound",

--- a/internal/config/testdata/all.yml
+++ b/internal/config/testdata/all.yml
@@ -1,0 +1,5 @@
+listenAddress: 127.0.0.10:9205
+timeout: 10s
+infoUrl: http://localhost
+username: testuser
+password: testpass

--- a/internal/config/testdata/all.yml
+++ b/internal/config/testdata/all.yml
@@ -1,5 +1,5 @@
 listenAddress: 127.0.0.10:9205
 timeout: 10s
-infoUrl: http://localhost
+server: http://localhost
 username: testuser
 password: testpass

--- a/internal/config/testdata/password
+++ b/internal/config/testdata/password
@@ -1,0 +1,1 @@
+testpass

--- a/internal/config/testdata/passwordfile.yml
+++ b/internal/config/testdata/passwordfile.yml
@@ -1,0 +1,5 @@
+listenAddress: 127.0.0.10:9205
+timeout: 10s
+server: http://localhost
+username: testuser
+password: "@testdata/password"

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/xperimental/nextcloud-exporter/internal/config"
 )
 
 var (
@@ -21,15 +22,15 @@ func main() {
 	log.SetFlags(0)
 	log.Printf("nextcloud-exporter %s", Version)
 
-	config, err := parseConfig()
+	cfg, err := config.Get()
 	if err != nil {
 		log.Fatalf("Error in configuration: %s", err)
 	}
 
-	log.Printf("Nextcloud server: %s User: %s", config.InfoURL.Hostname(), config.Username)
+	log.Printf("Nextcloud server: %s User: %s", cfg.InfoURL.Hostname(), cfg.Username)
 
 	userAgent := fmt.Sprintf("nextcloud-exporter/%s", Version)
-	collector := newCollector(config.InfoURL, config.Username, config.Password, config.Timeout, userAgent)
+	collector := newCollector(cfg.InfoURL, cfg.Username, cfg.Password, cfg.Timeout, userAgent)
 	if err := prometheus.Register(collector); err != nil {
 		log.Fatalf("Failed to register collector: %s", err)
 	}
@@ -50,6 +51,6 @@ func main() {
 	http.Handle("/metrics", promhttp.Handler())
 	http.Handle("/", http.RedirectHandler("/metrics", http.StatusFound))
 
-	log.Printf("Listen on %s...", config.ListenAddr)
-	log.Fatal(http.ListenAndServe(config.ListenAddr, nil))
+	log.Printf("Listen on %s...", cfg.ListenAddr)
+	log.Fatal(http.ListenAndServe(cfg.ListenAddr, nil))
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/xperimental/nextcloud-exporter/internal/config"
+	"github.com/xperimental/nextcloud-exporter/serverinfo"
 )
 
 var (
@@ -27,10 +28,12 @@ func main() {
 		log.Fatalf("Error in configuration: %s", err)
 	}
 
-	log.Printf("Nextcloud server: %s User: %s", cfg.InfoURL.Hostname(), cfg.Username)
+	log.Printf("Nextcloud server: %s User: %s", cfg.ServerURL, cfg.Username)
+
+	infoURL := cfg.ServerURL + serverinfo.InfoPath
 
 	userAgent := fmt.Sprintf("nextcloud-exporter/%s", Version)
-	collector := newCollector(cfg.InfoURL, cfg.Username, cfg.Password, cfg.Timeout, userAgent)
+	collector := newCollector(infoURL, cfg.Username, cfg.Password, cfg.Timeout, userAgent)
 	if err := prometheus.Register(collector); err != nil {
 		log.Fatalf("Failed to register collector: %s", err)
 	}

--- a/serverinfo/serverinfo.go
+++ b/serverinfo/serverinfo.go
@@ -2,6 +2,11 @@ package serverinfo
 
 import "encoding/xml"
 
+const (
+	// InfoPath contains the path to the serverinfo endpoint.
+	InfoPath = "/ocs/v2.php/apps/serverinfo/api/v1/info"
+)
+
 // ServerInfo contains the complete data received from the server.
 type ServerInfo struct {
 	Meta Meta `xml:"meta"`


### PR DESCRIPTION
This is a preparation for generating custom app passwords.

This removes the possibility to specify a custom serverinfo page. This feature was probably unused and maybe even has caused some of the issues posted by users.