### PR TITLE
Add github action auto build multi-arch images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         id: prep
         run: |
           TAGS=""
-          IMAGE="timtor/nextcloud-exporter"
+          IMAGE="xperimental/nextcloud-exporter"
 
           if [[ "$GITHUB_REF" == refs/heads/master ]]; then
             TAGS="$IMAGE:master"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Build and push docker images
+
+on:
+  push:
+    branches:
+      - "master"
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare
+        id: prep
+        run: |
+          TAGS=""
+          IMAGE="timtor/nextcloud-exporter"
+
+          if [[ "$GITHUB_REF" == refs/heads/master ]]; then
+            TAGS="$IMAGE:master"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+            TAGS="$IMAGE:$VERSION,$IMAGE:latest"
+          fi
+
+          echo "📚 building ref: $GITHUB_REF"
+          echo "🏷 image tags: $TAGS"
+          echo ::set-output name=tags::${TAGS}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          driver-opts: image=moby/buildkit:v0.8.1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login Docker hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags:  ${{ steps.prep.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
It seems #2 had discussed the nextcloud-exporter for different arch machines, like raspberry pi.
However, we still lack a place for community easily pull down and integrate into kubernetes or helm.

### Description
This github build action will be triggered while
- you push a commit on the master branch
- you push a tag on a commit

As the result, there will be three kind of image tag: the semver tag like `v0.4.0`, the `latest` tag refering the newest semver, and the `master` tag refering top most commit on the master branch.

### Note
Before merging, please add secrets DOCKER_USERNAME and DOCKER_TOKEN to the project secrets, enabling login into docker hub.