### PR TITLE
Add Information about total number of shares to shares_total_metric

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -249,6 +249,7 @@ func collectShares(ch chan<- prometheus.Metric, shares serverinfo.Shares) error 
 	values["group"] = float64(shares.SharesGroups)
 	values["authlink"] = float64(shares.SharesLink - shares.SharesLinkNoPassword)
 	values["link"] = float64(shares.SharesLink)
+	values["total"] = float64(shares.SharesTotal)
 
 	return collectMap(ch, sharesDesc, values)
 }


### PR DESCRIPTION
Hey,

I wanted to ask you if it is possible to add this information to the respective metric, it's useful for us, for showing the shares as a pie chart in a Grafana Dashboard for better usage analysis.

Kind Regards