### PR TITLE
Replace auth_errors metric by label on scrape errors metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ These metrics are exported by `nextcloud-exporter`:
 | nextcloud_active_users_total           | Number of active users for the last five minutes                       |
 | nextcloud_apps_installed_total         | Number of currently installed apps                                     |
 | nextcloud_apps_updates_available_total | Number of apps that have available updates                             |
-| nextcloud_auth_errors_total            | Counts number of authentication errors encountered by the collector    |
 | nextcloud_database_size_bytes          | Size of database in bytes as reported from engine                      |
 | nextcloud_exporter_info                | Contains meta information of the exporter. Value is always 1.          |
 | nextcloud_files_total                  | Number of files served by the instance                                 |


### PR DESCRIPTION
The description of the `nextcloud_auth_errors_total` has caused some confusion (see #48). This change replaces the separate metric for this error type with a label on the `nextcloud_scrape_errors_total` metric, which should make it clearer.