### PR TITLE
Export active users by time window labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ These metrics are exported by `nextcloud-exporter`:
 
 | name                                   | description                                                            |
 |----------------------------------------|------------------------------------------------------------------------|
-| nextcloud_active_users_total           | Number of active users for the last five minutes                       |
+| nextcloud_active_users_total           | Number of active users: <br> `5m`: within the last 5 minutes <br> `1h`: within the last hour <br> `1d`: within the last 24 hours |
 | nextcloud_apps_installed_total         | Number of currently installed apps                                     |
 | nextcloud_apps_updates_available_total | Number of apps that have available updates                             |
 | nextcloud_database_size_bytes          | Size of database in bytes as reported from engine                      |


### PR DESCRIPTION
This replaces the metric for active users within last 5 minutes with a combined metric containing all values provided by NC serverinfo:

```diff
 # HELP nextcloud_active_users_total Number of active users.
 # TYPE nextcloud_active_users_total gauge
-nextcloud_active_users_total 6
+nextcloud_active_users_total{window="1d"} 25
+nextcloud_active_users_total{window="1h"} 9
+nextcloud_active_users_total{window="5m"} 6
```

I'm not sure how strict you are w.r.t backwards compatibility, but from my understanding this change shouldn't break existing queries, only output 3 instead of one value.