### PR TITLE
Clarify loading token from file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,18 @@ timeout: "5s"
 tlsSkipVerify: false
 ```
 
-### Password file
+### Password / token file
 
-Optionally the password can be read from a separate file instead of directly from the input methods above. This can be achieved by setting the password to the path of the password file prefixed with an "@", for example:
+Optionally the password or auth token can be read from a separate file instead of directly from the input methods above. This can be achieved by setting the password / token to the path of the password file prefixed with an "@", for example:
 
 ```bash
 nextcloud-exporter -c config-without-password.yml -p @/path/to/passwordfile
 ```
+or
+```bash
+nextcloud-exporter -c config-without-token.yml --auth-token @/path/to/tokenfile
+```
+This also works when configuring via environment variables, which can be used for Docker secrets.
 
 ## Other information
 

--- a/README.md
+++ b/README.md
@@ -136,18 +136,20 @@ timeout: "5s"
 tlsSkipVerify: false
 ```
 
-### Password / token file
+### Loading Credentials from Files
 
-Optionally the password or auth token can be read from a separate file instead of directly from the input methods above. This can be achieved by setting the password / token to the path of the password file prefixed with an "@", for example:
+Both the authentication token and the password can optionally be read from a separate file instead of directly from the input methods above.
+
+This can be achieved by setting the value to the path of the file prefixed with an "@", for example:
 
 ```bash
+# Authentication token
+nextcloud-exporter -c config-without-token.yml --auth-token @/path/to/tokenfile
+# Password
 nextcloud-exporter -c config-without-password.yml -p @/path/to/passwordfile
 ```
-or
-```bash
-nextcloud-exporter -c config-without-token.yml --auth-token @/path/to/tokenfile
-```
-This also works when configuring via environment variables, which can be used for Docker secrets.
+
+This also works when the password or token is set using one of the other configuration modes (configuration file or environment variables).
 
 ## Other information
 


### PR DESCRIPTION
Both the password and the auth token can be read from a file by using `@/path/to/passwordfile`. The Readme only specifies this for the password, not for the token, even though it works for both.

This just clarifies the use with the token.