### PR TITLE
Makefile:8: *** missing separator.  Stop.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GIT_VERSION := $(shell git describe --tags --dirty)
 VERSION := $(GIT_VERSION:v%=%)
 GIT_COMMIT := $(shell git rev-parse HEAD)
 GITHUB_REF ?= refs/heads/master
-DOCKER_TAG != if [[ "$(GITHUB_REF)" == "refs/heads/master" ]]; then \
+DOCKER_TAG = if [[ "$(GITHUB_REF)" == "refs/heads/master" ]]; then \
 		echo "latest"; \
 	else \
 		echo "$(VERSION)"; \


### PR DESCRIPTION
Hello,

when I tried to build the binary I got this error.

```
[root@iron nextcloud-exporter]# make
+ git describe --tags --dirty
+ git rev-parse HEAD
Makefile:8: *** missing separator.  Stop.
```

I think there is a typo in your makefile.

I propose you this fix.

after applying this patch I did not have any more the issue.

```
[root@iron nextcloud-exporter]# make
+ git describe --tags --dirty
+ git rev-parse HEAD
CGO_ENABLED=0 go test -cover ./...
+ CGO_ENABLED=0
+ go test -cover ./...
go: downloading github.com/google/go-cmp v0.5.9
go: downloading github.com/prometheus/client_golang v1.13.0
go: downloading github.com/spf13/pflag v1.0.5
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading github.com/sirupsen/logrus v1.9.0
go: downloading golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
go: downloading github.com/prometheus/common v0.37.0
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/golang/protobuf v1.5.2
go: downloading github.com/cespare/xxhash/v2 v2.1.2
go: downloading google.golang.org/protobuf v1.28.1
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/prometheus/procfs v0.8.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
?       github.com/xperimental/nextcloud-exporter       [no test files]
ok      github.com/xperimental/nextcloud-exporter/internal/client       0.014s  coverage: 86.4% of statements
ok      github.com/xperimental/nextcloud-exporter/internal/config       0.011s  coverage: 87.5% of statements
ok      github.com/xperimental/nextcloud-exporter/internal/login        0.018s  coverage: 64.3% of statements
?       github.com/xperimental/nextcloud-exporter/internal/metrics      [no test files]
ok      github.com/xperimental/nextcloud-exporter/internal/testutil     0.012s  coverage: 100.0% of statements
ok      github.com/xperimental/nextcloud-exporter/serverinfo    0.009s  coverage: 57.1% of statements
CGO_ENABLED=0 go build -tags netgo -ldflags "-w -X main.Version=0.6.0-1-g69d6b67-dirty -X main.GitCommit=69d6b673fc79019d98f11a03c8bcf2acda16182b" -o nextcloud-exporter .
+ CGO_ENABLED=0
+ go build -tags netgo -ldflags '-w -X main.Version=0.6.0-1-g69d6b67-dirty -X main.GitCommit=69d6b673fc79019d98f11a03c8bcf2acda16182b' -o nextcloud-exporter .
```


Best regards


