### PR TITLE
Change behavior of Docker tags

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,6 +6,9 @@ on:
   release:
     types:
     - published
+  pull_request:
+    branches:
+    - master
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -31,7 +34,6 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
-      id: buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
@@ -44,7 +46,22 @@ jobs:
       with:
         username: xperimental
         password: ${{ secrets.DOCKER_TOKEN }}
-    - name: Build image
-      run: make all-images
-      env:
-        GITHUB_REF: ${{ github.ref }}
+    - name: Docker Metadata
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ghcr.io/xperimental/nextcloud-exporter
+          xperimental/nextcloud-exporter
+        tags: |
+          type=semver,pattern={{version}}
+          type=ref,event=branch
+          type=ref,event=pr
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,19 +4,6 @@ on:
     branches:
     - master
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Setup Go
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: go.mod
-    - name: Build and Test
-      run: make
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `latest` Docker tag now points to most recent release and `master` points to the build from the default branch
+
 ## [0.6.0] - 2022-10-19
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-FROM golang:1.19.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.19.9-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN apk add --no-cache make git bash
 
 WORKDIR /build
 
@@ -7,9 +15,9 @@ RUN go mod download
 RUN go mod verify
 
 COPY . /build/
-RUN make
+RUN make build-binary
 
-FROM busybox
+FROM --platform=$TARGETPLATFORM busybox
 LABEL maintainer="Robert Jacob <xperimental@solidproject.de>"
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,8 @@ GO_CMD := CGO_ENABLED=0 $(GO)
 GIT_VERSION := $(shell git describe --tags --dirty)
 VERSION := $(GIT_VERSION:v%=%)
 GIT_COMMIT := $(shell git rev-parse HEAD)
-GITHUB_REF ?= refs/heads/master
-DOCKER_TAG != if [[ "$(GITHUB_REF)" == "refs/heads/master" ]]; then \
-		echo "latest"; \
-	else \
-		echo "$(VERSION)"; \
-	fi
+DOCKER_REPO ?= xperimental/nextcloud-exporter
+DOCKER_TAG ?= dev
 
 .PHONY: all
 all: test build-binary
@@ -40,11 +36,11 @@ install:
 
 .PHONY: image
 image:
-	docker build -t "xperimental/nextcloud-exporter:$(DOCKER_TAG)" .
+	docker buildx build -t "ghcr.io/$(DOCKER_REPO):$(DOCKER_TAG)" --load .
 
 .PHONY: all-images
 all-images:
-	docker buildx build -t "ghcr.io/xperimental/nextcloud-exporter:$(DOCKER_TAG)" -t "xperimental/nextcloud-exporter:$(DOCKER_TAG)" --platform linux/amd64,linux/arm64 --push .
+	docker buildx build -t "ghcr.io/$(DOCKER_REPO):$(DOCKER_TAG)" -t "docker.io/$(DOCKER_REPO):$(DOCKER_TAG)" --platform linux/amd64,linux/arm64 --push .
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@ A [prometheus](https://prometheus.io) exporter for getting some metrics of a [Ne
 
 The preferred way to use `nextcloud-exporter` is by running the provided Docker image. It is currently provided on Docker Hub and GitHub Container Registry:
 
-```plain
-docker pull ghcr.io/xperimental/nextcloud-exporter:latest
-docker pull xperimental/nextcloud-exporter:latest
-```
+- [`ghcr.io/xperimental/nextcloud-exporter`](https://github.com/xperimental/nextcloud-exporter/pkgs/container/nextcloud-exporter)
+- [`xperimental/nextcloud-exporter`](https://hub.docker.com/r/xperimental/nextcloud-exporter/)
 
-In addition to the `latest` tag which points to the version currently in the `master` branch, tagged versions are also available.
+The following tags are available:
 
-### From Source
+- `x.y.z` pointing to the release with that version
+- `latest` pointing to the most recent released version
+- `master` pointing to the latest build from the default branch
+
+### Build from Source
 
 If you have a recent (>= 1.16) working Go installation and GNU Make, getting the binary should be as simple as
 


### PR DESCRIPTION
This changes the behavior of the Docker tags to the following schema:

- `master` will refer to the latest build from the default branch
- Versions `x.y.z` will refer to the build for that released version
- `latest` will point to the latest released version

Effectively this adds a `master` tag to replace the current `latest` tag and makes `latest` point to the latest release instead. The aim of this is to make usage of `latest` more stable.