### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2023-05-29
+
 ### Changed
 
 - `latest` Docker tag now points to most recent release and `master` points to the build from the default branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[0.6.1]: https://github.com/xperimental/nextcloud-exporter/releases/tag/v0.6.1
 [0.6.0]: https://github.com/xperimental/nextcloud-exporter/releases/tag/v0.6.0
 [0.5.1]: https://github.com/xperimental/nextcloud-exporter/releases/tag/v0.5.1
 [0.5.0]: https://github.com/xperimental/nextcloud-exporter/releases/tag/v0.5.0


### PR DESCRIPTION
This is a maintenance release:

- Updates Go and module dependencies
- Updates Github Actions used in workflows
- Changes the behavior of the `latest` Docker tag
