### PR TITLE
Make app-related metrics opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- App-related metrics (installed, available updates) are opt-in now, mirroring the change in Nextcloud 28
+
 ## [0.6.2] - 2023-10-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Usage of nextcloud-exporter:
   -a, --addr string          Address to listen on for connections. (default ":9205")
       --auth-token string    Authentication token. Can replace username and password when using Nextcloud 22 or newer.
   -c, --config-file string   Path to YAML configuration file.
+      --info-skip-apps       Skip metrics for installed apps and app updates.
       --login                Use interactive login to create app password.
   -p, --password string      Password for connecting to Nextcloud.
   -s, --server string        URL to Nextcloud server.
@@ -119,6 +120,7 @@ All settings can also be specified through environment variables:
 |  `NEXTCLOUD_LISTEN_ADDRESS` | --addr            |
 |         `NEXTCLOUD_TIMEOUT` | --timeout         |
 | `NEXTCLOUD_TLS_SKIP_VERIFY` | --tls-skip-verify |
+|  `NEXTCLOUD_INFO_SKIP_APPS` | --info-skip-apps  |
 
 #### Configuration file
 
@@ -136,6 +138,7 @@ password: "example"
 listenAddress: ":9205"
 timeout: "5s"
 tlsSkipVerify: false
+infoSkipApps: false
 ```
 
 ### Loading Credentials from Files
@@ -183,24 +186,24 @@ scrape_configs:
 
 These metrics are exported by `nextcloud-exporter`:
 
-| name                                   | description                                                            |
-|----------------------------------------|------------------------------------------------------------------------|
-| nextcloud_active_users_daily_total     | Number of active users in the last 24 hours                            |
-| nextcloud_active_users_hourly_total    | Number of active users in the last hour                                |
-| nextcloud_active_users_total           | Number of active users for the last five minutes                       |
-| nextcloud_apps_installed_total         | Number of currently installed apps                                     |
-| nextcloud_apps_updates_available_total | Number of apps that have available updates                             |
-| nextcloud_database_info                | Contains meta information about the database as labels. Value is always 1. |
-| nextcloud_database_size_bytes          | Size of database in bytes as reported from engine                      |
-| nextcloud_exporter_info                | Contains meta information of the exporter. Value is always 1.          |
-| nextcloud_files_total                  | Number of files served by the instance                                 |
-| nextcloud_free_space_bytes             | Free disk space in data directory in bytes                             |
-| nextcloud_php_info                     | Contains meta information about PHP as labels. Value is always 1.      |
-| nextcloud_php_memory_limit_bytes       | Configured PHP memory limit in bytes                                   |
-| nextcloud_php_upload_max_size_bytes    | Configured maximum upload size in bytes                                |
-| nextcloud_scrape_errors_total          | Counts the number of scrape errors by this collector                   |
-| nextcloud_shares_federated_total       | Number of federated shares by direction `sent` / `received`            |
+| name                                   | description                                                                                                                                                                                                             |
+|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| nextcloud_active_users_daily_total     | Number of active users in the last 24 hours                                                                                                                                                                             |
+| nextcloud_active_users_hourly_total    | Number of active users in the last hour                                                                                                                                                                                 |
+| nextcloud_active_users_total           | Number of active users for the last five minutes                                                                                                                                                                        |
+| nextcloud_apps_installed_total         | Number of currently installed apps                                                                                                                                                                                      |
+| nextcloud_apps_updates_available_total | Number of apps that have available updates                                                                                                                                                                              |
+| nextcloud_database_info                | Contains meta information about the database as labels. Value is always 1.                                                                                                                                              |
+| nextcloud_database_size_bytes          | Size of database in bytes as reported from engine                                                                                                                                                                       |
+| nextcloud_exporter_info                | Contains meta information of the exporter. Value is always 1.                                                                                                                                                           |
+| nextcloud_files_total                  | Number of files served by the instance                                                                                                                                                                                  |
+| nextcloud_free_space_bytes             | Free disk space in data directory in bytes                                                                                                                                                                              |
+| nextcloud_php_info                     | Contains meta information about PHP as labels. Value is always 1.                                                                                                                                                       |
+| nextcloud_php_memory_limit_bytes       | Configured PHP memory limit in bytes                                                                                                                                                                                    |
+| nextcloud_php_upload_max_size_bytes    | Configured maximum upload size in bytes                                                                                                                                                                                 |
+| nextcloud_scrape_errors_total          | Counts the number of scrape errors by this collector                                                                                                                                                                    |
+| nextcloud_shares_federated_total       | Number of federated shares by direction `sent` / `received`                                                                                                                                                             |
 | nextcloud_shares_total                 | Number of shares by type: <br> `authlink`: shared password protected links <br> `group`: shared groups <br>`link`: all shared links <br> `user`: shared users <br> `mail`: shared by mail <br> `room`: shared with room |
-| nextcloud_system_info                  | Contains meta information about Nextcloud as labels. Value is always 1.|
-| nextcloud_up                           | Indicates if the metrics could be scraped by the exporter: <br>`1`: successful<br>`0`: unsuccessful (server down, server/endpoint not reachable, invalid credentials, ...) |
-| nextcloud_users_total                  | Number of users of the instance                                        |
+| nextcloud_system_info                  | Contains meta information about Nextcloud as labels. Value is always 1.                                                                                                                                                 |
+| nextcloud_up                           | Indicates if the metrics could be scraped by the exporter: <br>`1`: successful<br>`0`: unsuccessful (server down, server/endpoint not reachable, invalid credentials, ...)                                              |
+| nextcloud_users_total                  | Number of users of the instance                                                                                                                                                                                         |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Usage of nextcloud-exporter:
   -a, --addr string          Address to listen on for connections. (default ":9205")
       --auth-token string    Authentication token. Can replace username and password when using Nextcloud 22 or newer.
   -c, --config-file string   Path to YAML configuration file.
-      --info-skip-apps       Skip metrics for installed apps and app updates.
+      --enable-info-apps     Enable gathering of apps-related metrics.
       --login                Use interactive login to create app password.
   -p, --password string      Password for connecting to Nextcloud.
   -s, --server string        URL to Nextcloud server.
@@ -111,16 +111,16 @@ There are three methods of configuring the nextcloud-exporter (higher methods ta
 
 All settings can also be specified through environment variables:
 
-|        Environment variable | Flag equivalent   |
-|----------------------------:|:------------------|
-|          `NEXTCLOUD_SERVER` | --server          |
-|        `NEXTCLOUD_USERNAME` | --username        |
-|        `NEXTCLOUD_PASSWORD` | --password        |
-|      `NEXTCLOUD_AUTH_TOKEN` | --auth-token      |
-|  `NEXTCLOUD_LISTEN_ADDRESS` | --addr            |
-|         `NEXTCLOUD_TIMEOUT` | --timeout         |
-| `NEXTCLOUD_TLS_SKIP_VERIFY` | --tls-skip-verify |
-|  `NEXTCLOUD_INFO_SKIP_APPS` | --info-skip-apps  |
+|        Environment variable | Flag equivalent    |
+|----------------------------:|:-------------------|
+|          `NEXTCLOUD_SERVER` | --server           |
+|        `NEXTCLOUD_USERNAME` | --username         |
+|        `NEXTCLOUD_PASSWORD` | --password         |
+|      `NEXTCLOUD_AUTH_TOKEN` | --auth-token       |
+|  `NEXTCLOUD_LISTEN_ADDRESS` | --addr             |
+|         `NEXTCLOUD_TIMEOUT` | --timeout          |
+| `NEXTCLOUD_TLS_SKIP_VERIFY` | --tls-skip-verify  |
+|       `NEXTCLOUD_INFO_APPS` | --enable-info-apps |
 
 #### Configuration file
 
@@ -138,7 +138,8 @@ password: "example"
 listenAddress: ":9205"
 timeout: "5s"
 tlsSkipVerify: false
-infoSkipApps: false
+info:
+  apps: false
 ```
 
 ### Loading Credentials from Files

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -170,6 +170,25 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
+			desc: "auth token env, skip apps",
+			args: []string{
+				"test",
+			},
+			env: map[string]string{
+				envServerURL:    "http://localhost",
+				envAuthToken:    "auth-token",
+				envInfoSkipApps: "true",
+			},
+			wantErr: nil,
+			wantConfig: Config{
+				ListenAddr:   defaults.ListenAddr,
+				Timeout:      defaults.Timeout,
+				ServerURL:    "http://localhost",
+				AuthToken:    "auth-token",
+				InfoSkipApps: true,
+			},
+		},
+		{
 			desc: "token file",
 			args: []string{
 				"test",
@@ -279,6 +298,16 @@ func TestConfig(t *testing.T) {
 				envTLSSkipVerify: "invalid",
 			},
 			wantErr: errors.New(`error reading environment variables: can not parse value for "NEXTCLOUD_TLS_SKIP_VERIFY": invalid`),
+		},
+		{
+			desc: "fail parsing infoSkipApps env",
+			args: []string{
+				"test",
+			},
+			env: map[string]string{
+				envInfoSkipApps: "invalid",
+			},
+			wantErr: errors.New(`error reading environment variables: can not parse value for "NEXTCLOUD_INFO_SKIP_APPS": invalid`),
 		},
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -175,17 +175,19 @@ func TestConfig(t *testing.T) {
 				"test",
 			},
 			env: map[string]string{
-				envServerURL:    "http://localhost",
-				envAuthToken:    "auth-token",
-				envInfoSkipApps: "true",
+				envServerURL: "http://localhost",
+				envAuthToken: "auth-token",
+				envInfoApps:  "true",
 			},
 			wantErr: nil,
 			wantConfig: Config{
-				ListenAddr:   defaults.ListenAddr,
-				Timeout:      defaults.Timeout,
-				ServerURL:    "http://localhost",
-				AuthToken:    "auth-token",
-				InfoSkipApps: true,
+				ListenAddr: defaults.ListenAddr,
+				Timeout:    defaults.Timeout,
+				ServerURL:  "http://localhost",
+				AuthToken:  "auth-token",
+				Info: InfoConfig{
+					Apps: true,
+				},
 			},
 		},
 		{
@@ -305,9 +307,9 @@ func TestConfig(t *testing.T) {
 				"test",
 			},
 			env: map[string]string{
-				envInfoSkipApps: "invalid",
+				envInfoApps: "invalid",
 			},
-			wantErr: errors.New(`error reading environment variables: can not parse value for "NEXTCLOUD_INFO_SKIP_APPS": invalid`),
+			wantErr: errors.New(`error reading environment variables: can not parse value for "NEXTCLOUD_INFO_APPS": invalid`),
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -74,14 +74,14 @@ func main() {
 		log.Infof("Nextcloud server: %s Authentication using token.", cfg.ServerURL)
 	}
 
-	infoURL := cfg.ServerURL + serverinfo.InfoPath
+	infoURL := serverinfo.InfoURL(cfg.ServerURL, cfg.InfoSkipApps)
 
 	if cfg.TLSSkipVerify {
 		log.Warn("HTTPS certificate verification is disabled.")
 	}
 
 	infoClient := client.New(infoURL, cfg.Username, cfg.Password, cfg.AuthToken, cfg.Timeout, userAgent, cfg.TLSSkipVerify)
-	if err := metrics.RegisterCollector(log, infoClient); err != nil {
+	if err := metrics.RegisterCollector(log, infoClient, !cfg.InfoSkipApps); err != nil {
 		log.Fatalf("Failed to register collector: %s", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -74,14 +74,14 @@ func main() {
 		log.Infof("Nextcloud server: %s Authentication using token.", cfg.ServerURL)
 	}
 
-	infoURL := serverinfo.InfoURL(cfg.ServerURL, cfg.InfoSkipApps)
+	infoURL := serverinfo.InfoURL(cfg.ServerURL, !cfg.Info.Apps)
 
 	if cfg.TLSSkipVerify {
 		log.Warn("HTTPS certificate verification is disabled.")
 	}
 
 	infoClient := client.New(infoURL, cfg.Username, cfg.Password, cfg.AuthToken, cfg.Timeout, userAgent, cfg.TLSSkipVerify)
-	if err := metrics.RegisterCollector(log, infoClient, !cfg.InfoSkipApps); err != nil {
+	if err := metrics.RegisterCollector(log, infoClient, cfg.Info.Apps); err != nil {
 		log.Fatalf("Failed to register collector: %s", err)
 	}
 

--- a/serverinfo/serverinfo.go
+++ b/serverinfo/serverinfo.go
@@ -7,11 +7,6 @@ import (
 	"strconv"
 )
 
-const (
-	// InfoPath contains the path to the serverinfo endpoint.
-	InfoPath = "/ocs/v2.php/apps/serverinfo/api/v1/info?format=json"
-)
-
 // ServerInfo contains the complete data received from the server.
 type ServerInfo struct {
 	Meta Meta `json:"meta"`

--- a/serverinfo/url.go
+++ b/serverinfo/url.go
@@ -1,0 +1,14 @@
+package serverinfo
+
+import (
+	"fmt"
+)
+
+const (
+	infoPathFormat = "%s/ocs/v2.php/apps/serverinfo/api/v1/info?format=json&skipApps=%v"
+)
+
+// InfoURL constructs the URL of the info endpoint from the server base URL and optional parameters.
+func InfoURL(serverURL string, skipApps bool) string {
+	return fmt.Sprintf(infoPathFormat, serverURL, skipApps)
+}

--- a/serverinfo/url_test.go
+++ b/serverinfo/url_test.go
@@ -1,0 +1,38 @@
+package serverinfo
+
+import (
+	"testing"
+)
+
+func TestInfoURL(t *testing.T) {
+	tt := []struct {
+		desc      string
+		serverURL string
+		skipApps  bool
+		wantURL   string
+	}{
+		{
+			desc:      "default",
+			serverURL: "https://nextcloud.example.com",
+			wantURL:   "https://nextcloud.example.com/ocs/v2.php/apps/serverinfo/api/v1/info?format=json&skipApps=false",
+		},
+		{
+			desc:      "skip apps",
+			serverURL: "https://nextcloud.example.com",
+			skipApps:  true,
+			wantURL:   "https://nextcloud.example.com/ocs/v2.php/apps/serverinfo/api/v1/info?format=json&skipApps=true",
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			url := InfoURL(tc.serverURL, tc.skipApps)
+			if url != tc.wantURL {
+				t.Errorf("got url %q, want %q", url, tc.wantURL)
+			}
+		})
+	}
+}

--- a/serverinfo/url_test.go
+++ b/serverinfo/url_test.go
@@ -12,7 +12,7 @@ func TestInfoURL(t *testing.T) {
 		wantURL   string
 	}{
 		{
-			desc:      "default",
+			desc:      "do not skip apps",
 			serverURL: "https://nextcloud.example.com",
 			wantURL:   "https://nextcloud.example.com/ocs/v2.php/apps/serverinfo/api/v1/info?format=json&skipApps=false",
 		},


### PR DESCRIPTION
Nextcloud 26 introduced a new parameter to the serverinfo resource ("skipApps"), which allows disabling information about app updates. Nextcloud 28 changes the default of this parameter, making the app information opt-in, making the app-related metrics empty when using Nextcloud 28.

This PR adds an option to the exporter, which allows enabling the app-related metrics again. Similar to the newest Nextcloud version it makes the app metrics opt-in.