### PR TITLE
doc: clarify which dashboard is official

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ After starting the server will offer the metrics on the `/metrics` endpoint, whi
 
 The repository contains an [example Grafana dashboard](contrib/grafana-dashboard.json) that can be imported into Grafana. The dashboard is also available as ID `20716` from the [Grafana Dashboard Exchange](https://grafana.com/grafana/dashboards/20716-nextcloud/).
 
+Note that there is an old dashboard [Nextcloud Exporter Prometheus Dashboard](https://grafana.com/grafana/dashboards/11033-nextcloud/) by me that is no longer maintained. you can safely ignore this.
+
 ### Configuration methods
 
 There are three methods of configuring the nextcloud-exporter (higher methods take precedence over lower ones):

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ After starting the server will offer the metrics on the `/metrics` endpoint, whi
 
 The repository contains an [example Grafana dashboard](contrib/grafana-dashboard.json) that can be imported into Grafana. The dashboard is also available as ID `20716` from the [Grafana Dashboard Exchange](https://grafana.com/grafana/dashboards/20716-nextcloud/).
 
-Note that there is an old dashboard [Nextcloud Exporter Prometheus Dashboard](https://grafana.com/grafana/dashboards/11033-nextcloud/) by me that is no longer maintained. you can safely ignore this.
+*Note: there may be other Grafana dashboards created by the community to use data from this exporter. [This one](https://grafana.com/grafana/dashboards/20716-nextcloud/) is the "official" dashboard, as shown by the `Published by: xperimental`. Others may have issues or be outdated.*
 
 ### Configuration methods
 


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>

Hi,

Thank you for making all this, it's really nice.

I actually heard about that repo by searching for `nextcloud` in the grafana dashboard list and clicked the links in the description. There is apparently [an old](https://grafana.com/grafana/dashboards/11033-nextcloud/) dashboard by you that was last updated 6 years ago and I thought I had to install both or something.

So I made a quick doc PR to clarify that situation.


Hope that helps.

Thanks again.


Edit: Whoops I was even more confused than I thought and now understand more which is the official one. I pushed further clarifications.