### PR TITLE
Extend scrape error metric to show service unavailable and maintenance mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Additional label on `nextcloud_scrape_errors_total` for HTTP Service Unavailable (503) errors
-- Additional label on `nextcloud_scrape_errors_total` for maintenance mode
+- Additional labels on `nextcloud_scrape_errors_total`
+  - `unavailable` for HTTP Service Unavailable (503) errors
+  - `maintenance` for maintenance mode
 
 ## [0.8.0] - 2024-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Additional label on `nextcloud_scrape_errors_total` for HTTP Service Unavailable (503) errors
+
 ## [0.8.0] - 2024-12-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Additional label on `nextcloud_scrape_errors_total` for HTTP Service Unavailable (503) errors
+- Additional label on `nextcloud_scrape_errors_total` for maintenance mode
 
 ## [0.8.0] - 2024-12-22
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -17,6 +17,7 @@ const (
 var (
 	ErrNotAuthorized = errors.New("wrong credentials")
 	ErrRatelimit     = errors.New("too many requests")
+	ErrUnavailable   = errors.New("service unavailable / maintenance mode")
 )
 
 type InfoClient func() (*serverinfo.ServerInfo, error)
@@ -59,6 +60,8 @@ func New(infoURL, username, password, authToken string, timeout time.Duration, u
 			return nil, ErrNotAuthorized
 		case http.StatusTooManyRequests:
 			return nil, ErrRatelimit
+		case http.StatusServiceUnavailable:
+			return nil, ErrUnavailable
 		default:
 			return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
 		}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -15,9 +15,10 @@ const (
 )
 
 var (
-	ErrNotAuthorized = errors.New("wrong credentials")
-	ErrRatelimit     = errors.New("too many requests")
-	ErrUnavailable   = errors.New("service unavailable / maintenance mode")
+	ErrNotAuthorized   = errors.New("wrong credentials")
+	ErrRatelimit       = errors.New("too many requests")
+	ErrUnavailable     = errors.New("service unavailable")
+	ErrMaintenanceMode = errors.New("maintenance mode")
 )
 
 type InfoClient func() (*serverinfo.ServerInfo, error)
@@ -61,6 +62,10 @@ func New(infoURL, username, password, authToken string, timeout time.Duration, u
 		case http.StatusTooManyRequests:
 			return nil, ErrRatelimit
 		case http.StatusServiceUnavailable:
+			if res.Header.Get("X-Nextcloud-Maintenance-Mode") != "" {
+				return nil, ErrMaintenanceMode
+			}
+
 			return nil, ErrUnavailable
 		default:
 			return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -13,9 +13,10 @@ import (
 const (
 	metricPrefix = "nextcloud_"
 
-	labelErrorCauseOther     = "other"
-	labelErrorCauseAuth      = "auth"
-	labelErrorCauseRatelimit = "ratelimit"
+	labelErrorCauseOther       = "other"
+	labelErrorCauseAuth        = "auth"
+	labelErrorCauseRatelimit   = "ratelimit"
+	labelErrorCauseUnavailable = "unavailable"
 )
 
 var (
@@ -142,6 +143,8 @@ func (c *nextcloudCollector) Collect(ch chan<- prometheus.Metric) {
 			cause = labelErrorCauseAuth
 		case errors.Is(err, client.ErrRatelimit):
 			cause = labelErrorCauseRatelimit
+		case errors.Is(err, client.ErrUnavailable):
+			cause = labelErrorCauseUnavailable
 		}
 		c.scrapeErrorsMetric.WithLabelValues(cause).Inc()
 		c.upMetric.Set(0)

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
 	"github.com/xperimental/nextcloud-exporter/internal/client"
 	"github.com/xperimental/nextcloud-exporter/serverinfo"
 )
@@ -17,6 +18,7 @@ const (
 	labelErrorCauseAuth        = "auth"
 	labelErrorCauseRatelimit   = "ratelimit"
 	labelErrorCauseUnavailable = "unavailable"
+	labelErrorCauseMaintenance = "maintenance"
 )
 
 var (
@@ -145,6 +147,8 @@ func (c *nextcloudCollector) Collect(ch chan<- prometheus.Metric) {
 			cause = labelErrorCauseRatelimit
 		case errors.Is(err, client.ErrUnavailable):
 			cause = labelErrorCauseUnavailable
+		case errors.Is(err, client.ErrMaintenanceMode):
+			cause = labelErrorCauseMaintenance
 		}
 		c.scrapeErrorsMetric.WithLabelValues(cause).Inc()
 		c.upMetric.Set(0)


### PR DESCRIPTION
Nextcloud maintenance mode will cause the exporter to not be able to fetch the metrics anymore, which shows as `nextcloud_scrape_errors_total` increasing. This PR adds new labels to that metric that show generic HTTP 503 ("Service Unavailable") errors and such errors which also have the header emitted by Nextcloud when in maintenance mode.

This PR adds new labels on the error metric to distinguish these errors from others.